### PR TITLE
Support Elixir 1.18 in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -16,20 +16,21 @@ jobs:
       fail-fast: false
       matrix:
         elixir:
-        - '1.17'
-        - '1.16'
-        - '1.15'
-        - '1.14'
-        - '1.13'
-        - '1.12'
-        - '1.11'
-        - '1.10'
-        - '1.9'
-        - '1.8'
-        - '1.7'
+          - '1.18'
+          - '1.17'
+          - '1.16'
+          - '1.15'
+          - '1.14'
+          - '1.13'
+          - '1.12'
+          - '1.11'
+          - '1.10'
+          - '1.9'
+          - '1.8'
+          - '1.7'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment
         run: |
@@ -46,9 +47,9 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.17
+      image: elixir:1.18
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment
         run: |
@@ -64,11 +65,11 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.17
+      image: elixir:1.18
     env:
       MIX_ENV: cover
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment
         run: |
@@ -86,9 +87,9 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.17
+      image: elixir:1.18
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment
         run: |
@@ -110,9 +111,9 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.17
+      image: elixir:1.18
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Environment
         run: |


### PR DESCRIPTION
List of changes:
- bump GitHub Actions
- fix incorrect indentation
- use latest Elixir 1.18